### PR TITLE
Have the ability to delete messages but without affecting the other users

### DIFF
--- a/src/main/java/com/projecty/projectyweb/message/MessageController.java
+++ b/src/main/java/com/projecty/projectyweb/message/MessageController.java
@@ -121,9 +121,9 @@ public class MessageController {
         }
     }
 
-    @DeleteMapping
+    @DeleteMapping(value = "{id}")
     public void deleteMessage(
-            @RequestParam Long messageId
+            @PathVariable("id") long messageId
     ) {
         Optional<Message> optMessage = messageRepository.findById(messageId);
         optMessage.ifPresent(messageService::deleteMessage);

--- a/src/main/java/com/projecty/projectyweb/message/MessageController.java
+++ b/src/main/java/com/projecty/projectyweb/message/MessageController.java
@@ -1,10 +1,13 @@
 package com.projecty.projectyweb.message;
 
 import com.projecty.projectyweb.configurations.AnyPermission;
+import com.projecty.projectyweb.message.association.AssociationService;
 import com.projecty.projectyweb.message.attachment.Attachment;
 import com.projecty.projectyweb.message.attachment.AttachmentService;
 import com.projecty.projectyweb.user.User;
 import com.projecty.projectyweb.user.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -27,13 +30,16 @@ public class MessageController {
 
     private final MessageService messageService;
 
+    private final AssociationService associationService;
+
     private final AttachmentService attachmentService;
 
-    public MessageController(UserService userService, MessageRepository messageRepository, MessageService messageService, AttachmentService attachmentService) {
+    public MessageController(UserService userService, MessageRepository messageRepository, MessageService messageService, AttachmentService attachmentService , AssociationService associationService) {
         this.userService = userService;
         this.messageRepository = messageRepository;
         this.messageService = messageService;
         this.attachmentService = attachmentService;
+        this.associationService = associationService;
     }
 
     @GetMapping("receivedMessages")
@@ -81,12 +87,19 @@ public class MessageController {
 
     @GetMapping("viewMessage")
     @AnyPermission
-    public Message viewMessage(
+    public ResponseEntity<Message> viewMessage(
             @RequestParam Long messageId
     ) {
         Optional<Message> optMessage = messageRepository.findById(messageId);
-        messageService.updateSeenDate(optMessage.get());
-        return optMessage.get();
+        if(optMessage.isPresent()) {
+            final Message message = optMessage.get();
+            if (associationService.isVisibleForUser(message, userService.getCurrentUser())) {
+                messageService.updateSeenDate(message);
+                return ResponseEntity.ok(message);
+            }
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
     }
 
     @GetMapping("getUnreadMessageCount")
@@ -107,4 +120,13 @@ public class MessageController {
             throw new BindException(bindingResult);
         }
     }
+
+    @DeleteMapping
+    public void deleteMessage(
+            @RequestParam Long messageId
+    ) {
+        Optional<Message> optMessage = messageRepository.findById(messageId);
+        optMessage.ifPresent(messageService::deleteMessage);
+    }
+
 }

--- a/src/main/java/com/projecty/projectyweb/message/MessageService.java
+++ b/src/main/java/com/projecty/projectyweb/message/MessageService.java
@@ -17,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -104,5 +105,8 @@ public class MessageService {
     public void deleteMessage(Message message){
         User currentUser = userService.getCurrentUser();
         associationService.deleteMessageForUser(message,currentUser);
+        if(Objects.isNull(message.getSender())&& Objects.isNull(message.getRecipient())){
+           messageRepository.delete(message);
+        }
     }
 }

--- a/src/main/java/com/projecty/projectyweb/message/MessageService.java
+++ b/src/main/java/com/projecty/projectyweb/message/MessageService.java
@@ -1,5 +1,7 @@
 package com.projecty.projectyweb.message;
 
+import com.projecty.projectyweb.message.association.AssociationRepository;
+import com.projecty.projectyweb.message.association.AssociationService;
 import com.projecty.projectyweb.message.attachment.AttachmentService;
 import com.projecty.projectyweb.user.User;
 import com.projecty.projectyweb.user.UserRepository;
@@ -16,32 +18,36 @@ import org.springframework.web.server.ResponseStatusException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
 public class MessageService {
-    private static UserService userService;
-    private static MessageRepository messageRepository;
+    private final UserService userService;
+    private final AssociationService associationService;
+    private final MessageRepository messageRepository;
     private final UserRepository userRepository;
     private final MessageSource messageSource;
     private final AttachmentService attachmentService;
 
-    public MessageService(UserService userService, MessageRepository messageRepository, UserRepository userRepository, MessageSource messageSource, AttachmentService attachmentService) {
-        MessageService.userService = userService;
-        MessageService.messageRepository = messageRepository;
+    public MessageService(UserService userService, MessageRepository messageRepository, UserRepository userRepository, MessageSource messageSource, AttachmentService attachmentService,AssociationService associationService) {
+        this.userService = userService;
+        this.messageRepository = messageRepository;
         this.userRepository = userRepository;
         this.messageSource = messageSource;
         this.attachmentService = attachmentService;
+        this.associationService = associationService;
     }
 
     public int getUnreadMessageCountForCurrentUser() {
         User current = userService.getCurrentUser();
-        return messageRepository.findByRecipientAndSeenDateIsNull(current).size();
+        return (int) messageRepository.findByRecipientAndSeenDateIsNull(current).stream()
+                .filter(message -> this.associationService.isVisibleForUser(message, current))
+                .count();
     }
 
     public boolean checkIfCurrentUserHasPermissionToView(Message message) {
-        User current = userService.getCurrentUser();
-        return message.getRecipient().equals(current) || message.getSender().equals(current);
+        return this.associationService.isVisibleForUser(message,userService.getCurrentUser());
     }
 
     public void updateSeenDate(Message message) {
@@ -73,15 +79,17 @@ public class MessageService {
                 attachmentService.addFilesToMessage(multipartFiles, message);
             }
             messageRepository.save(message);
+            associationService.recordMessage(message);
         }
     }
+
 
     public void reply(Long replyToMessageId,
                       Message message,
                       BindingResult bindingResult,
                       List<MultipartFile> multipartFiles) {
         Optional<Message> replyToMessage = messageRepository.findById(replyToMessageId);
-        if(replyToMessage.isPresent()) {
+        if (replyToMessage.isPresent()) {
             message.setReplyToMessage(replyToMessage.get());
             sendMessage(
                     replyToMessage.get().getSender().getUsername(),
@@ -91,5 +99,10 @@ public class MessageService {
         } else {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
+    }
+
+    public void deleteMessage(Message message){
+        User currentUser = userService.getCurrentUser();
+        associationService.deleteMessageForUser(message,currentUser);
     }
 }

--- a/src/main/java/com/projecty/projectyweb/message/association/Association.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/Association.java
@@ -1,0 +1,45 @@
+package com.projecty.projectyweb.message.association;
+
+import com.projecty.projectyweb.message.Message;
+import com.projecty.projectyweb.user.User;
+
+import javax.persistence.*;
+
+@Entity
+public class Association {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/projecty/projectyweb/message/association/Association.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/Association.java
@@ -19,6 +19,15 @@ public class Association {
     @JoinColumn(name = "message_id")
     private Message message;
 
+    @PreRemove
+    public void preRemove() {
+        if(message.getSender().equals(user)) {
+            message.setSender(null);
+        }else {
+            message.setRecipient(null);
+        }
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/projecty/projectyweb/message/association/AssociationRepository.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/AssociationRepository.java
@@ -1,0 +1,11 @@
+package com.projecty.projectyweb.message.association;
+
+import com.projecty.projectyweb.message.Message;
+import com.projecty.projectyweb.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AssociationRepository extends JpaRepository<Association, Long> {
+    List<Association> findByUser(User user);
+}

--- a/src/main/java/com/projecty/projectyweb/message/association/AssociationRepository.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/AssociationRepository.java
@@ -5,7 +5,8 @@ import com.projecty.projectyweb.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AssociationRepository extends JpaRepository<Association, Long> {
-    List<Association> findByUser(User user);
+    Optional<Association>  findFirstByUserAndMessage(User user, Message message);
 }

--- a/src/main/java/com/projecty/projectyweb/message/association/AssociationService.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/AssociationService.java
@@ -35,16 +35,12 @@ public class AssociationService {
     }
 
     public void deleteMessageForUser(Message messageToBeDeleted, User user){
-        Optional<Association> messageOptional = associationRepository.findByUser(user).stream()
-                .filter(association -> messageToBeDeleted.equals(association.getMessage()))
-                .findFirst();
+        Optional<Association> messageOptional = associationRepository.findFirstByUserAndMessage(user,messageToBeDeleted);
         messageOptional.ifPresent(associationRepository::delete);
     }
     public boolean isVisibleForUser(Message message,User user){
         if(message.getRecipient().equals(user) || message.getSender().equals(user)){
-            Optional<Association> messageOptional = associationRepository.findByUser(user).stream()
-                    .filter(association -> message.equals(association.getMessage()))
-                    .findFirst();
+            Optional<Association> messageOptional = associationRepository.findFirstByUserAndMessage(user,message);
             return messageOptional.isPresent();
         }
         return false;

--- a/src/main/java/com/projecty/projectyweb/message/association/AssociationService.java
+++ b/src/main/java/com/projecty/projectyweb/message/association/AssociationService.java
@@ -1,0 +1,52 @@
+package com.projecty.projectyweb.message.association;
+
+import com.projecty.projectyweb.message.Message;
+import com.projecty.projectyweb.user.User;
+import com.projecty.projectyweb.user.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+@Service
+public class AssociationService {
+
+    private final UserService userService;
+
+    private final AssociationRepository associationRepository;
+
+
+    public AssociationService(UserService userService , AssociationRepository associationRepository){
+        this.userService = userService;
+        this.associationRepository = associationRepository;
+    }
+
+    public void recordMessage(Message mesage){
+        Association senderAssociation = new Association();
+        senderAssociation.setMessage(mesage);
+        senderAssociation.setUser(mesage.getSender());
+
+        associationRepository.save(senderAssociation);
+
+        Association recipientAssociation = new Association();
+        recipientAssociation.setMessage(mesage);
+        recipientAssociation.setUser(mesage.getRecipient());
+
+        associationRepository.save(recipientAssociation);
+    }
+
+    public void deleteMessageForUser(Message messageToBeDeleted, User user){
+        Optional<Association> messageOptional = associationRepository.findByUser(user).stream()
+                .filter(association -> messageToBeDeleted.equals(association.getMessage()))
+                .findFirst();
+        messageOptional.ifPresent(associationRepository::delete);
+    }
+    public boolean isVisibleForUser(Message message,User user){
+        if(message.getRecipient().equals(user) || message.getSender().equals(user)){
+            Optional<Association> messageOptional = associationRepository.findByUser(user).stream()
+                    .filter(association -> message.equals(association.getMessage()))
+                    .findFirst();
+            return messageOptional.isPresent();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/projecty/projectyweb/user/User.java
+++ b/src/main/java/com/projecty/projectyweb/user/User.java
@@ -157,21 +157,6 @@ public class User implements Serializable {
         this.projectRoles = projectRoles;
     }
 
-    public List<Message> getMessagesFrom() {
-        return messagesFrom;
-    }
-
-    public void setMessagesFrom(List<Message> messagesFrom) {
-        this.messagesFrom = messagesFrom;
-    }
-
-    public List<Message> getMessagesTo() {
-        return messagesTo;
-    }
-
-    public void setMessagesTo(List<Message> messagesTo) {
-        this.messagesTo = messagesTo;
-    }
 
     public List<TeamRole> getTeamRoles() {
         return teamRoles;

--- a/src/test/java/com/projecty/projectyweb/message/MessageControllerTests.java
+++ b/src/test/java/com/projecty/projectyweb/message/MessageControllerTests.java
@@ -118,9 +118,9 @@ public class MessageControllerTests {
                 .thenReturn(Optional.ofNullable(replyMessage));
 
 
-        Mockito.when(associationRepository.findByUser(Mockito.eq(user1))).thenReturn(Collections.singletonList(associationForSender));
-        Mockito.when(associationRepository.findByUser(Mockito.eq(user2))).thenReturn(Collections.emptyList());
-        Mockito.when(associationRepository.findByUser(Mockito.eq(user))).thenReturn(Collections.singletonList(associationForRecipient));
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user1),any(Message.class))).thenReturn(Optional.ofNullable(associationForSender));
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user2),any(Message.class))).thenReturn(Optional.empty());
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user),any(Message.class))).thenReturn(Optional.ofNullable(associationForRecipient));
     }
 
     @Test

--- a/src/test/java/com/projecty/projectyweb/message/MessageControllerTests.java
+++ b/src/test/java/com/projecty/projectyweb/message/MessageControllerTests.java
@@ -1,6 +1,8 @@
 package com.projecty.projectyweb.message;
 
 import com.projecty.projectyweb.ProjectyWebApplication;
+import com.projecty.projectyweb.message.association.Association;
+import com.projecty.projectyweb.message.association.AssociationRepository;
 import com.projecty.projectyweb.message.attachment.Attachment;
 import com.projecty.projectyweb.user.User;
 import com.projecty.projectyweb.user.UserRepository;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.sql.rowset.serial.SerialBlob;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -40,12 +43,18 @@ public class MessageControllerTests {
     @MockBean(name = "messageRepository")
     MessageRepository messageRepository;
 
+    @MockBean(name="associationRepository")
+    AssociationRepository associationRepository;
+
     @Autowired
     private MockMvc mockMvc;
 
     private Message message;
     private Message replyMessage;
     private String recipientUsername;
+
+    private Association associationForRecipient;
+    private Association associationForSender;
 
     @Before
     public void init() throws SQLException {
@@ -70,6 +79,18 @@ public class MessageControllerTests {
         recipientUsername = "user1";
         message.setRecipient(user);
         message.setSender(user1);
+
+
+        associationForRecipient = new Association();
+        associationForRecipient.setUser(user);
+        associationForRecipient.setMessage(message);
+        associationForRecipient.setId(1L);
+
+        associationForSender = new Association();
+        associationForSender.setUser(user1);
+        associationForSender.setMessage(message);
+        associationForSender.setId(2L);
+
         byte[] bytes = new byte[]{0, 1, 2, 3, 4, 5};
         Attachment attachment = new Attachment();
         attachment.setFile(new SerialBlob(bytes));
@@ -96,6 +117,10 @@ public class MessageControllerTests {
         Mockito.when(messageRepository.findById(replyMessage.getId()))
                 .thenReturn(Optional.ofNullable(replyMessage));
 
+
+        Mockito.when(associationRepository.findByUser(Mockito.eq(user1))).thenReturn(Collections.singletonList(associationForSender));
+        Mockito.when(associationRepository.findByUser(Mockito.eq(user2))).thenReturn(Collections.emptyList());
+        Mockito.when(associationRepository.findByUser(Mockito.eq(user))).thenReturn(Collections.singletonList(associationForRecipient));
     }
 
     @Test

--- a/src/test/java/com/projecty/projectyweb/message/association/AssociationServiceTest.java
+++ b/src/test/java/com/projecty/projectyweb/message/association/AssociationServiceTest.java
@@ -1,0 +1,99 @@
+package com.projecty.projectyweb.message.association;
+
+import com.projecty.projectyweb.ProjectyWebApplication;
+import com.projecty.projectyweb.message.Message;
+import com.projecty.projectyweb.message.MessageRepository;
+import com.projecty.projectyweb.user.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ProjectyWebApplication.class)
+public class AssociationServiceTest {
+    @MockBean(name = "messageRepository")
+    MessageRepository messageRepository;
+
+    @MockBean(name="associationRepository")
+    AssociationRepository associationRepository;
+
+
+
+    @Autowired
+    private AssociationService service;
+
+    private Association associationForRecipient;
+    private Association associationForSender;
+
+
+    private Message message;
+
+
+    private User user;
+    private User user2;
+    @Before
+    public void init(){
+        user = new User();
+        user.setId(2L);
+        user.setUsername("user");
+        user.setEmail("user@example.com");
+
+        user2 = new User();
+        user2.setId(3L);
+        user2.setUsername("user2");
+
+        message = new Message();
+        message.setId(1L);
+        message.setText("This is sample message");
+        message.setTitle("sample title");
+
+        message.setRecipient(user2);
+        message.setSender(user);
+
+
+        associationForRecipient = new Association();
+        associationForRecipient.setUser(user2);
+        associationForRecipient.setMessage(message);
+        associationForRecipient.setId(1L);
+
+        associationForSender = new Association();
+        associationForSender.setUser(user);
+        associationForSender.setMessage(message);
+        associationForSender.setId(2L);
+    }
+
+
+
+    @Test
+    public void deleteMessageForUser() {
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user), Mockito.eq(message)))
+                .thenReturn(Optional.of(associationForRecipient));
+        service.deleteMessageForUser(message,user);
+        verify(associationRepository, times(1)).delete(associationForRecipient);
+    }
+
+    @Test
+    public void isVisibleForUser() {
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user), Mockito.eq(message)))
+                .thenReturn(Optional.of(associationForRecipient));
+        Mockito.when(associationRepository.findFirstByUserAndMessage(Mockito.eq(user2), Mockito.eq(message)))
+                .thenReturn(Optional.of(associationForSender));
+        assertTrue(service.isVisibleForUser(message,user));
+        assertTrue(service.isVisibleForUser(message,user2));
+        assertFalse(service.isVisibleForUser(message,new User()));
+    }
+}


### PR DESCRIPTION
Create a service and a new entity that holds the relationship between the user and the message. If we delete the message we basically delete this association and not the actual message.

- needs to be done tests for the associations without mocking as it is fragile.
- create a script that creates these associations for existing data.